### PR TITLE
Fix hpk buffer size in masked_sk struct

### DIFF
--- a/crypto_kem/kyber768/m4/masked.h
+++ b/crypto_kem/kyber768/m4/masked.h
@@ -98,7 +98,7 @@ typedef struct {
 typedef struct {
     masked_polyvec indcpa_sk;
     uint8_t pk[KYBER_INDCPA_PUBLICKEYBYTES];
-    uint8_t hpk[KYBER_PUBLICKEYBYTES];
+    uint8_t hpk[KYBER_SYMBYTES];
     masked_u8_symbytes z;
 } masked_sk;
 


### PR DESCRIPTION
Change `hpk` from `KYBER_PUBLICKEYBYTES` (1184 bytes) to `KYBER_SYMBYTES` (32 bytes). hpk stores `H(pk)` which is a SHA3-256 hash output of 32 bytes.